### PR TITLE
Add extensive Python examples

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -1,1 +1,30 @@
-# Laten we iets in python maken om python te leren. 
+from file_handling import file_demo
+from loops import multiplication_table
+from datastructures import list_and_dict_demo
+
+
+def main_menu():
+    """Eenvoudig menu om voorbeelden te tonen."""
+    while True:
+        print("\nKies een optie:")
+        print("1. File handling voorbeeld")
+        print("2. Loops en functies voorbeeld")
+        print("3. Datastructuren voorbeeld")
+        print("4. Stoppen")
+
+        keuze = input("Maak een keuze: ").strip()
+        if keuze == "1":
+            file_demo()
+        elif keuze == "2":
+            multiplication_table()
+        elif keuze == "3":
+            list_and_dict_demo()
+        elif keuze == "4":
+            print("Programma afgesloten.")
+            break
+        else:
+            print("Ongeldige keuze, probeer opnieuw.")
+
+
+if __name__ == "__main__":
+    main_menu()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # Test
+
+Deze repository bevat losse Python scripts met voorbeelden die je kunnen helpen
+bij het leren voor een MBO niveau 4 examen.
+
+## Bestanden
+
+- `variables_and_types.py` - basis over variabelen en datatypen
+- `collections_examples.py` - werken met lijsten, tuples, sets en dictionaries
+- `control_flow.py` - voorbeelden van if-statements en loops
+- `functions_lambda.py` - functies en lambda-functies
+- `oop_examples.py` - klassen, objecten en overerving
+- `modules_example.py` - hoe je modules importeert
+- `exceptions_example.py` - basis exception handling
+- `file_handling.py` - schrijven en lezen van bestanden
+- `csv_example.py` - gebruik van de csv-module
+- `datetime_example.py` - werken met datum en tijd
+- `json_example.py` - JSON verwerken
+- `loops.py` - diverse loops
+- `datastructures.py` - lijst- en dictionaryoperaties
+- `Main.py` - optioneel menu om de voorbeelden te starten
+
+### Virtuele omgeving
+
+Voor grotere projecten kun je een virtuele omgeving gebruiken om
+pakketversies te beheren:
+
+```bash
+python -m venv venv
+source venv/bin/activate  # op Windows: venv\Scripts\activate
+```
+
+Installeer daarna je dependencies in deze omgeving.
+
+Je kunt elk script afzonderlijk uitvoeren met `python bestandsnaam.py` om de
+voorbeelden te zien.

--- a/collections_examples.py
+++ b/collections_examples.py
@@ -1,0 +1,36 @@
+"""Voorbeelden van verschillende collecties in Python."""
+
+
+def list_example():
+    """Laat zien hoe je met lijsten werkt."""
+    boodschappen = ["melk", "brood", "eieren"]  # lijst met drie items
+    boodschappen.append("kaas")  # voeg een item toe
+    for item in boodschappen:
+        print("Item:", item)
+
+
+def tuple_example():
+    """Toont gebruik van een tuple, een onveranderbare lijst."""
+    kleuren = ("rood", "groen", "blauw")
+    for kleur in kleuren:
+        print("Kleur:", kleur)
+
+
+def set_example():
+    """Demonstreert een set die geen dubbele waarden bevat."""
+    unieke_getallen = {1, 2, 3, 3}
+    print("Set:", unieke_getallen)
+
+
+def dict_example():
+    """Werkt met een dictionary van sleutel/waarde-paren."""
+    persoon = {"naam": "Lisa", "leeftijd": 22}
+    for sleutel, waarde in persoon.items():
+        print(f"{sleutel} -> {waarde}")
+
+
+if __name__ == "__main__":
+    list_example()
+    tuple_example()
+    set_example()
+    dict_example()

--- a/control_flow.py
+++ b/control_flow.py
@@ -1,0 +1,33 @@
+"""Uitleg over if-statements en loops."""
+
+
+def if_example(getal):
+    """Geeft aan of het getal positief, negatief of nul is."""
+    if getal > 0:
+        print("Positief")
+    elif getal < 0:
+        print("Negatief")
+    else:
+        print("Nul")
+
+
+def for_example():
+    """Loopt over een reeks getallen en toont elk getal."""
+    for i in range(3):
+        print("For-lus:", i)
+
+
+def while_example():
+    """Aftellen met een while-lus."""
+    teller = 3
+    while teller > 0:
+        print("Teller:", teller)
+        teller -= 1
+
+
+if __name__ == "__main__":
+    if_example(1)
+    if_example(-2)
+    if_example(0)
+    for_example()
+    while_example()

--- a/csv_example.py
+++ b/csv_example.py
@@ -1,0 +1,26 @@
+"""Werken met de csv-module."""
+
+import csv
+
+
+def write_csv(bestand):
+    """Schrijf voorbeeldgegevens naar een CSV-bestand."""
+    with open(bestand, "w", newline="", encoding="utf-8") as f:
+        schrijver = csv.writer(f)
+        schrijver.writerow(["naam", "leeftijd"])
+        schrijver.writerow(["Bram", 30])
+        schrijver.writerow(["Eva", 25])
+
+
+def read_csv(bestand):
+    """Lees een CSV-bestand en print de rijen."""
+    with open(bestand, "r", newline="", encoding="utf-8") as f:
+        lezer = csv.reader(f)
+        for rij in lezer:
+            print(rij)
+
+
+if __name__ == "__main__":
+    bestand = "voorbeeld.csv"
+    write_csv(bestand)
+    read_csv(bestand)

--- a/datastructures.py
+++ b/datastructures.py
@@ -1,0 +1,16 @@
+def list_and_dict_demo():
+    """Toont eenvoudige bewerkingen met lijsten en dictionaries."""
+    cijfers = [7, 8, 9]
+    cijfers.append(10)
+    print("Lijst:", cijfers)
+    for idx, waarde in enumerate(cijfers, start=1):
+        print(f"{idx}: {waarde}")
+
+    leerling = {"naam": "Alex", "leeftijd": 20, "opleiding": "ICT"}
+    print("Gegevens van leerling:")
+    for sleutel, waarde in leerling.items():
+        print(f"{sleutel}: {waarde}")
+
+
+if __name__ == "__main__":
+    list_and_dict_demo()

--- a/datetime_example.py
+++ b/datetime_example.py
@@ -1,0 +1,15 @@
+"""Demonstreert gebruik van het datetime-module."""
+
+from datetime import datetime, timedelta
+
+
+def tijd_demo():
+    """Print de huidige datum en tijd plus een dag."""
+    nu = datetime.now()
+    morgen = nu + timedelta(days=1)
+    print("Nu:", nu)
+    print("Morgen:", morgen)
+
+
+if __name__ == "__main__":
+    tijd_demo()

--- a/exceptions_example.py
+++ b/exceptions_example.py
@@ -1,0 +1,16 @@
+"""Demonstreert basis van exception handling."""
+
+
+def divide(a, b):
+    """Deelt a door b met foutafhandeling."""
+    try:
+        resultaat = a / b
+    except ZeroDivisionError:
+        print("Delen door nul kan niet")
+    else:
+        print("Resultaat:", resultaat)
+
+
+if __name__ == "__main__":
+    divide(10, 2)
+    divide(5, 0)

--- a/file_handling.py
+++ b/file_handling.py
@@ -1,0 +1,43 @@
+"""Voorbeelden van verschillende manieren om met bestanden te werken."""
+
+
+def write_example(bestand, tekst):
+    """Schrijf een tekst naar een nieuw bestand."""
+    with open(bestand, "w", encoding="utf-8") as f:
+        f.write(tekst)
+
+
+def append_example(bestand, tekst):
+    """Voeg tekst toe aan een bestaand bestand."""
+    with open(bestand, "a", encoding="utf-8") as f:
+        f.write(tekst)
+
+
+def read_example(bestand):
+    """Lees de volledige inhoud van een bestand en geef dit terug."""
+    with open(bestand, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def read_lines_example(bestand):
+    """Lees een bestand regel voor regel en print de regels."""
+    with open(bestand, "r", encoding="utf-8") as f:
+        for regel in f:
+            print(regel.strip())
+
+
+def file_demo():
+    """Demonstratie van schrijven, aanvullen en lezen."""
+    naam = "voorbeeld.txt"
+    write_example(naam, "Eerste regel\n")
+    append_example(naam, "Tweede regel\n")
+
+    print("Volledige inhoud:")
+    print(read_example(naam))
+
+    print("Regel voor regel lezen:")
+    read_lines_example(naam)
+
+
+if __name__ == "__main__":
+    file_demo()

--- a/functions_lambda.py
+++ b/functions_lambda.py
@@ -1,0 +1,21 @@
+"""Voorbeelden van functies en lambda-functies."""
+
+
+def square(number):
+    """Geeft het kwadraat van een getal terug."""
+    return number * number
+
+
+# Een lambda-functie doet hetzelfde maar in één regel
+square_lambda = lambda x: x * x
+
+
+def demo():
+    """Toont het gebruik van de gewone functie en de lambda."""
+    for i in range(3):
+        print("square():", square(i))
+        print("lambda:", square_lambda(i))
+
+
+if __name__ == "__main__":
+    demo()

--- a/json_example.py
+++ b/json_example.py
@@ -1,0 +1,19 @@
+"""Voorbeeld van JSON-verwerking."""
+
+import json
+
+
+def json_demo():
+    """Schrijft en leest een dict als JSON."""
+    data = {"naam": "Sara", "leeftijd": 28}
+    # Schrijf JSON naar een string
+    json_str = json.dumps(data)
+    print("JSON-string:", json_str)
+
+    # Lees JSON terug naar een dict
+    opnieuw = json.loads(json_str)
+    print("Terug naar dict:", opnieuw)
+
+
+if __name__ == "__main__":
+    json_demo()

--- a/loops.py
+++ b/loops.py
@@ -1,0 +1,46 @@
+"""Voorbeelden van verschillende soorten loops in Python."""
+
+
+def for_range_example():
+    """Itereert over een range van nummers."""
+    for i in range(5):
+        print(f"Range voorbeeld: {i}")
+
+
+def for_list_example():
+    """Loopt door een lijst en toont index en waarde."""
+    kleuren = ["rood", "groen", "blauw"]
+    for index, kleur in enumerate(kleuren):
+        print(f"{index}: {kleur}")
+
+
+def while_example():
+    """Eenvoudige while-lus die aftelt."""
+    count = 3
+    while count > 0:
+        print(f"Countdown: {count}")
+        count -= 1
+
+
+def nested_loop_example():
+    """Geneste loops om coordinaten te genereren."""
+    for x in range(2):
+        for y in range(2):
+            print(f"({x}, {y})")
+
+
+def multiplication_table():
+    """Print een kleine vermenigvuldigings-tabel."""
+    for i in range(1, 4):
+        for j in range(1, 4):
+            print(f"{i} x {j} = {i * j}")
+        print("-")
+
+
+if __name__ == "__main__":
+    # Voorbeelden worden uitgevoerd als dit bestand direct wordt gestart
+    for_range_example()
+    for_list_example()
+    while_example()
+    nested_loop_example()
+    multiplication_table()

--- a/modules_example.py
+++ b/modules_example.py
@@ -1,0 +1,13 @@
+"""Laat zien hoe modules geïmporteerd kunnen worden."""
+
+import math
+
+
+def module_demo():
+    """Gebruikt de math-module voor een simpele berekening."""
+    resultaat = math.sqrt(16)  # de wortel van 16 is 4
+    print("De wortel van 16 is", resultaat)
+
+
+if __name__ == "__main__":
+    module_demo()

--- a/oop_examples.py
+++ b/oop_examples.py
@@ -1,0 +1,33 @@
+"""Voorbeelden van klassen, objecten en overerving."""
+
+
+class Persoon:
+    """Een eenvoudige klasse met een naam."""
+
+    def __init__(self, naam):
+        self.naam = naam  # sla de naam op in het object
+
+    def groet(self):
+        """Print een groet met de naam."""
+        print(f"Hallo, ik ben {self.naam}")
+
+
+class Student(Persoon):
+    """Student erft van Persoon."""
+
+    def __init__(self, naam, opleiding):
+        super().__init__(naam)  # roep de constructor van Persoon aan
+        self.opleiding = opleiding
+
+    def groet(self):
+        """Overschrijf de groet-methode voor extra informatie."""
+        super().groet()
+        print(f"Ik volg de opleiding {self.opleiding}")
+
+
+if __name__ == "__main__":
+    piet = Persoon("Piet")
+    piet.groet()
+
+    anna = Student("Anna", "ICT")
+    anna.groet()

--- a/variables_and_types.py
+++ b/variables_and_types.py
@@ -1,0 +1,30 @@
+"""Uitleg over variabelen en datatypen in Python.
+
+Dit script laat zien hoe je verschillende soorten waardes kunt opslaan in
+variabelen. Per functie worden de belangrijkste datatypen uitgelegd.
+"""
+
+
+def variable_examples():
+    """Toont eenvoudige voorbeelden van variabelen en datatypen."""
+    # Een integer is een geheel getal
+    leeftijd = 21
+
+    # Een float bevat een kommagetal
+    gewicht = 72.5
+
+    # Een string bevat tekst
+    naam = "Alex"
+
+    # Een boolean is True of False
+    ingeschreven = True
+
+    # We printen de variabelen zodat je de waarden kunt zien
+    print("Leeftijd:", leeftijd)
+    print("Gewicht:", gewicht)
+    print("Naam:", naam)
+    print("Ingeschreven:", ingeschreven)
+
+
+if __name__ == "__main__":
+    variable_examples()


### PR DESCRIPTION
## Summary
- add many small tutorial scripts for core Python concepts
- expand `loops.py` with a multiplication table example
- update README with list of examples and info about virtual envs

## Testing
- `python -m py_compile *.py`
- `python variables_and_types.py`
- `python collections_examples.py`
- `python control_flow.py`
- `python functions_lambda.py`
- `python oop_examples.py`
- `python modules_example.py`
- `python exceptions_example.py`
- `python file_handling.py`
- `python csv_example.py`
- `python datetime_example.py`
- `python json_example.py`


------
https://chatgpt.com/codex/tasks/task_e_683f54fb80dc83279eaaea835ea96012